### PR TITLE
Potential fix for code scanning alert no. 1: URL redirection from remote source

### DIFF
--- a/pprxweb/scorebrowser/views.py
+++ b/pprxweb/scorebrowser/views.py
@@ -12,7 +12,7 @@ from django.shortcuts import redirect, render
 from django.template.loader import render_to_string
 from django.urls import reverse
 from django.utils.encoding import force_bytes, force_str
-from django.utils.http import urlsafe_base64_decode, urlsafe_base64_encode
+from django.utils.http import urlsafe_base64_decode, urlsafe_base64_encode, url_has_allowed_host_and_scheme
 from django.views.decorators.csrf import csrf_exempt
 from numpy import interp
 from .forms import SetPasswordForm, UpdateEmailForm, UserRegistrationForm
@@ -92,7 +92,9 @@ def login_user(request):
 
 			users = User.objects.filter(django_user=django_user)
 			next_url = request.POST.get('next')
-			return redirect(next_url or 'landing') if users else redirect('link_sanbai')
+			if not url_has_allowed_host_and_scheme(next_url, allowed_hosts={request.get_host()}):
+				next_url = 'landing'
+			return redirect(next_url) if users else redirect('link_sanbai')
 	else:
 		form = AuthenticationForm(request)
 


### PR DESCRIPTION
Potential fix for [https://github.com/ScottBrenner/pprx/security/code-scanning/1](https://github.com/ScottBrenner/pprx/security/code-scanning/1)

To fix the issue, we need to validate the `next_url` parameter before using it in the `redirect` function. The Django utility function `url_has_allowed_host_and_scheme` can be used to ensure that the URL is safe. This function checks that the URL is either relative or belongs to an allowed host.

Steps to fix:
1. Import `url_has_allowed_host_and_scheme` from `django.utils.http`.
2. Validate `next_url` using `url_has_allowed_host_and_scheme`. If it is not valid, fall back to a safe default (e.g., `'landing'`).
3. Update the `redirect` call to use the validated URL.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
